### PR TITLE
Use HTTPS for profile and Facebook links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,7 +34,7 @@ author:
   url:            'https://nikunjlad.dev'
   email:          'lad.n@husky.neu.edu'
   github:         'https://github.com/nikunjlad'
-  facebook:       'http://www.facebook.com/nikunj.sporty'
+  facebook:       'https://www.facebook.com/nikunj.sporty'
   twitter:        'https://twitter.com/LadNikunj'
   googleplus:     ''
   linkedin:       'https://www.linkedin.com/in/nikunjlad '

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-  <link href="http://gmpg.org/xfn/11" rel="profile">
+  <link href="https://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 


### PR DESCRIPTION
## Summary
- switch profile link to HTTPS
- update Facebook URL to HTTPS

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll; install missing gem executables)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6b69238c83278432ffab6a9575a4