### PR TITLE
Load ipmeta API key from configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,6 +45,7 @@ paginate:         3
 
 # Custom vars
 version:          2.1.0
+ipmeta_api_key:   "" # set or use environment variable IPMETA_API_KEY
 
 github:
   repo:           https://github.com/nikunjlad/nikunjlad.github.io

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -76,7 +76,7 @@
 
   <script>
      provideGtagPlugin({
-        apiKey: '80209597e254c5cc9900cf363aea73150a4dc0ffd8bbb8ceae52cc889333e4ab',
+        apiKey: '{{ site.ipmeta_api_key | default: ENV["IPMETA_API_KEY"] }}',
         serviceProvider: 'dimension1',
         networkDomain: 'dimension2',
         networkType: 'dimension3',


### PR DESCRIPTION
## Summary
- remove hard-coded ipmeta.io API key from head include
- allow providing key via `_config.yml` or `IPMETA_API_KEY` environment variable

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6c3facb083278e155a1ada71a6a5