### PR TITLE
Remove dead Sourcerer link and centralize intro styling

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,13 +6,12 @@ title: Home
 <div id="textbox">
     <div class="alignleft">
         <div id="element1"><a href="https://scholar.google.com/citations?user=is6g3oAAAAAJ&hl=en" target="_blank"><img src="img/google.png" alt="google-scholars" width="35" height="35"></a></div>
-        <div id="element2"><a href="https://sourcerer.io/nikunjlad" target="_blank"><img src="img/sourcerer.png" alt="sourcerer" width="35" height="35"></a></div>
-    </div> 
+    </div>
 </div>
 <div style="clear: both;"></div>
 
 
-<span style="color:#000; font-family: 'Montserrat'; font-size: 2.1em;"><b>Hi, I'm Nikunj.</b></span>
+<span class="intro-heading"><b>Hi, I'm Nikunj.</b></span>
 
 I love building [Computer Vision](https://www.sas.com/en_us/insights/analytics/computer-vision.html){:target="_blank"} applications and programming in Python.
 Currently, I am working on developing efficient dataloading pipelines for large datasets using multiprocessing and multi-threading strategies.

--- a/public/css/nikunj.css
+++ b/public/css/nikunj.css
@@ -12,7 +12,12 @@
 }
 
 #element1 {display:inline-block; margin-right:9px}
-#element2 {display:inline-block}
+.intro-heading {
+    color: #000;
+    font-family: "Montserrat", sans-serif;
+    font-size: 2.1em;
+}
+
 
 /* Font */
 html {


### PR DESCRIPTION
## Summary
- Drop defunct Sourcerer social link from home page
- Replace inline intro span styling with reusable CSS class

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_b_68bf6c3ef5388327882e2e549312fef0