### PR TITLE
Add descriptive alt text and aria labels for accessibility

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -45,22 +45,22 @@
 
     <ul class="list-inline" id="sidebar-buttons">
         <li>
-            <a href="mailto:{{ site.author.email }}" class="btn-social btn-outline" title="E-Mail me">
+            <a href="mailto:{{ site.author.email }}" class="btn-social btn-outline" title="E-Mail me" aria-label="E-Mail me">
                 <i class="fa fa-fw fa-at"></i>
             </a>
         </li>
         <li>
-            <a href="{{ site.author.github }}" target="_blank" class="btn-social btn-outline" title="Nikunj on GitHub">
+            <a href="{{ site.author.github }}" target="_blank" class="btn-social btn-outline" title="Nikunj on GitHub" aria-label="Nikunj on GitHub">
                 <i class="fa fa-fw fa-github"></i>
             </a>
         </li>
         <li>
-            <a href="{{ site.author.twitter }}" target="_blank" class="btn-social btn-outline" title="@LadNikunj on Twitter">
+            <a href="{{ site.author.twitter }}" target="_blank" class="btn-social btn-outline" title="@LadNikunj on Twitter" aria-label="@LadNikunj on Twitter">
                 <i class="fa fa-fw fa-twitter"></i>
             </a>
         </li>
         <li>
-            <a href="{{ site.author.linkedin}}" target="_blank" class="btn-social btn-outline" title="Nikunj Lad on LinkedIn">
+            <a href="{{ site.author.linkedin}}" target="_blank" class="btn-social btn-outline" title="Nikunj Lad on LinkedIn" aria-label="Nikunj Lad on LinkedIn">
                 <i class="fa fa-fw fa-linkedin"></i>
             </a>
         </li>

--- a/index.md
+++ b/index.md
@@ -5,8 +5,8 @@ title: Home
 
 <div id="textbox">
     <div class="alignleft">
-        <div id="element1"><a href="https://scholar.google.com/citations?user=is6g3oAAAAAJ&hl=en" target="_blank"><img src="img/google.png" alt="google-scholars" width="35" height="35"></a></div>
-        <div id="element2"><a href="https://sourcerer.io/nikunjlad" target="_blank"><img src="img/sourcerer.png" alt="sourcerer" width="35" height="35"></a></div>
+        <div id="element1"><a href="https://scholar.google.com/citations?user=is6g3oAAAAAJ&hl=en" target="_blank"><img src="img/google.png" alt="Google Scholar profile" width="35" height="35"></a></div>
+        <div id="element2"><a href="https://sourcerer.io/nikunjlad" target="_blank"><img src="img/sourcerer.png" alt="Sourcerer profile" width="35" height="35"></a></div>
     </div> 
 </div>
 <div style="clear: both;"></div>


### PR DESCRIPTION
## Summary
- Improve alt text for profile icons on home page
- Add `aria-label` attributes to sidebar social links

## Testing
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6c3bd0808327a122c2300eb6f3dd