### PR TITLE
Add favicon and link in head

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+public/favicon.ico text

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,7 +55,7 @@
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ site.baseurl }}/public/apple-touch-icon-144-precomposed.png">
-  <!-- <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico"> -->
+  <link rel="shortcut icon" href="{{ site.baseurl }}/public/favicon.ico">
 
   <!-- Feed (jekyll-feed) -->
   {% feed_meta %}

--- a/public/favicon.ico
+++ b/public/favicon.ico
@@ -1,0 +1,1 @@
+Placeholder favicon. Replace with real favicon.ico.


### PR DESCRIPTION
## Summary
- add placeholder `favicon.ico` in `public`
- include shortcut icon link in site head to reference the new favicon
- ensure Git treats `favicon.ico` as text for diffs

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6c0ffe008327ab1f7d6e2b74a336