### PR TITLE
Clean up sidebar navigation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # nikunjlad.github.io
+
+Source for Nikunj Lad's personal site powered by [Jekyll](https://jekyllrb.com).
+
+## Sidebar navigation
+
+Navigation links in [`_includes/sidebar.html`](./_includes/sidebar.html) are
+manually curated instead of generated from all pages. Keeping this list short
+helps the template stay concise and highlights the most relevant content.
+Add new links directly in that file when necessary.
+

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -10,25 +10,7 @@
     </div>
 
     <nav class="sidebar-nav">
-      <!-- <a class="sidebar-nav-item{% if page.url == site.baseurl %} active{% endif %}" href="{{ site.baseurl }}/">Home</a> -->
-
-      {% comment %}
-        The code below dynamically generates a sidebar nav of pages with
-        `layout: page` in the front-matter. See readme for usage.
-
-
-      {% assign pages_list = site.pages %}
-      {% for node in pages_list %}
-        {% if node.title != null %}
-          {% if node.layout == "page" %}
-            <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ site.baseurl }}{{ node.url }}">{{ node.title }}</a>
-          {% endif %}
-        {% endif %}
-      {% endfor %}
-
-      {% endcomment %}
-
-
+      <!-- Navigation links are intentionally curated below to keep the template concise. -->
       <a class="sidebar-nav-item"
          href="{{ site.baseurl }}/about/">About</a>
       <!-- <a class="sidebar-nav-item"


### PR DESCRIPTION
## Summary
- remove unused dynamic navigation loop from sidebar
- note that sidebar links are manually curated to stay concise
- document navigation curation in README

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_68bf6c43361c8327b7b5557228219ca9